### PR TITLE
[docs] Clarify the role of the url param

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ function loadRepos(userId) {
   return function (dispatch, getState) {
     const url = `https://api.github.com/users/${userId}/repos`;
 
+    // The `url` param sent to attemptRequest isn't used for anything request related.
+    // It's used as a hash key to keep track of duplicate requests.
+    // If you're sending a POST request, unique data in headers, etc
+    // append any additional identifying information to the `url` string and redux-requests will de-dupe
     attemptRequest(url, {
       begin: () => ({
         type: 'LOAD_REPOS',
@@ -73,7 +77,7 @@ The `attemptRequest` function is actually just a simple helper (and is completel
 
 1. Add `meta.httpRequest` fields to your Action objects
   - `meta.httpRequest.url` is required, and will be used as the unique identifier for the request
-  - `meta.httpRequest.done` is a boolean indiecating if this action corresponds to a beginning or ending part of the request sequence
+  - `meta.httpRequest.done` is a boolean indicating if this action corresponds to a beginning or ending part of the request sequence
     - Typically a successful response Action and a failed response Action will both have `meta.httpRequest.done = true`
 2. Check if the `dispatch` for your initial request Action was cancelled (`dispatch` will return `undefined`), and if so, prevent issuing the request
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Reducer function to handle pending requests.
  * @param  {Object} state  Existing state object.
  * @param  {Object} action Incoming action:
- *                         - Ations with the meta.httpRequest property are examined.
+ *                         - Actions with the meta.httpRequest property are examined.
  *                         - The meta.httpRequest.url property is added or removed
  *                           from the current state depending on if the meta.httpRequest.done
  *                           property is set.


### PR DESCRIPTION
Added a snippet in the docs to clarify the role of the url parameter to help solve possible confusion when using non-GET fetch calls.

Fixed two small typos as well.
